### PR TITLE
Adding .gitignore with users/init.php and various backup globs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+users/init.php
+*~
+*.swp
+*.bak


### PR DESCRIPTION
This will prevent us from checking in our users/init.php and also keep various backup files from being listed and cluttering up the picture with `git status`
