### PR TITLE
Relative redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+users/init.php
+*~
+*.swp
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-users/init.php
-*~
-*.swp
-*.bak

--- a/users/classes/Redirect.php
+++ b/users/classes/Redirect.php
@@ -20,37 +20,26 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 class Redirect {
     public static function to($location = null, $args=''){
         global $us_url_root;
+        #echo "DEBUG: Redirect::to($location): entering<br />\n";
         #die("Redirecting to $location<br />\n");
         if ($location) {
-            if (is_numeric($location)) {
-                switch ($location) {
-                    case '404':
-                        header('HTTP/1.0 404 Not found');
-                        include 'includes/errors/404.php';
-                        break;
-                }
+            if ($location == basename($_SERVER['SCRIPT_NAME'])) {
+              bold("Circular redirect");
+              return; // avoid circular redirects
             }
-            if (!preg_match('/^https?:\/\//', $location) && !file_exists($location)) {
-                foreach (array($us_url_root, '../', 'users/', substr($us_url_root, 1), '../../', '/', '/users/') as $prefix) {
-                    if (file_exists($prefix.$location)) {
-                        $location = $prefix.$location;
-                        break;
-                    }
-                }
-            }
+            $location = findPageLocation($location); // searches root, usersc/, users/, etc.
             if ($args) $location .= $args; // allows 'login.php?err=Error+Message' or the like
             if (!headers_sent()){
                 header('Location: '.$location);
-            exit();
-        } else {
-        echo '<script type="text/javascript">';
-        echo 'window.location.href="'.$location.'";';
-        echo '</script>';
-        echo '<noscript>';
-        echo '<meta http-equiv="refresh" content="0;url='.$location.'" />';
-        echo '</noscript>'; exit;
-        }
+                exit();
+            } else {
+                echo '<script type="text/javascript">';
+                echo 'window.location.href="'.$location.'";';
+                echo '</script>';
+                echo '<noscript>';
+                echo '<meta http-equiv="refresh" content="0;url='.$location.'" />';
+                echo '</noscript>'; exit;
+            }
         }
     }
-
 }

--- a/users/edit_profile.php
+++ b/users/edit_profile.php
@@ -52,7 +52,7 @@ if(!empty($_POST)) {
         ));
       if($validation->passed()){
         $db->update('profiles',$id,$fields);
-        Redirect::to('profile.php?id='.$userID);
+        Redirect::to('profile.php', '?id='.$userID);
       }
     }
   }

--- a/users/email_settings.php
+++ b/users/email_settings.php
@@ -24,19 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 <?php if (!securePage($_SERVER['PHP_SELF'])){die();} ?>
 <?php
-// What to look for
-$search = "Redirect::to('verify.php');";
-// Read from file
-$lines = file('init.php');
-foreach($lines as $line)
-{
-  if(strpos($line, $search) !== false)
-    bold("<br><br>You have a bug in your init.php that cannot be patched automatically.<br><br>Please replace verify.php with users/verify.php towards the bottom of your init.php file.");
-}
-
 
 $urlProtocol=isset($_SERVER['HTTPS']) ? 'https://' : 'http://';
-
 
 if(!empty($_POST)){
 

--- a/users/helpers/us_helpers.php
+++ b/users/helpers/us_helpers.php
@@ -415,7 +415,7 @@ function securePage($uri){
 	}elseif ($pageDetails['private'] == 0){//If page is public, allow access
 		return true;
 	}elseif(!$user->isLoggedIn()){ //If user is not logged in, deny access
-		Redirect::to($us_url_root.'users/login.php', '?afterLoginGoto='.$page);
+		Redirect::to('login.php', '?afterLoginGoto='.$page);
 		return false;
 	}else {
 		//Retrieve list of permission levels with access to page
@@ -626,4 +626,24 @@ function updateEmail($id, $email) {
 	$db->update('users',$id,$fields);
 
 	return true;
+}
+
+//Given a page name, locate the preferred path to that page_footer
+function findPageLocation($pagename) {
+	global $abs_us_root, $us_url_root;
+  if (preg_match('/^https?:\/\//', $pagename)) {
+		return $pagename;
+	}
+  if (!$dirlist = Config::get('page_search_paths')) {
+      $root = $us_url_root;
+      $dirlist = array($root, $root.'usersc/', $root.'users/', './', '../', '../../');
+  }
+  foreach ($dirlist as $prefix) {
+      if (($prefix{0} == '.' && file_exists($prefix.$pagename)) ||
+						($prefix{0} == '/' && file_exists($abs_us_root.$prefix.$pagename))) {
+          $location = $prefix.$pagename;
+          break;
+      }
+  }
+	return $location;
 }

--- a/users/includes/navigation.php
+++ b/users/includes/navigation.php
@@ -66,35 +66,35 @@ $email_act=$results->email_act;
 		<div class="collapse navbar-collapse navbar-top-menu-collapse navbar-right">
 			<ul class="nav navbar-nav ">
 				<?php if($user->isLoggedIn()){ //anyone is logged in?>
-					<li><a href="<?=$us_url_root?>users/account.php"><i class="fa fa-fw fa-user"></i> <?php echo ucfirst($user->data()->username);?></a></li> <!-- Common for Hamburger and Regular menus link -->
+					<li><a href="<?=findPageLocation('account.php')?>"><i class="fa fa-fw fa-user"></i> <?php echo ucfirst($user->data()->username);?></a></li> <!-- Common for Hamburger and Regular menus link -->
 					<li class="hidden-sm hidden-md hidden-lg"><a href="<?=$us_url_root?>"><i class="fa fa-fw fa-home"></i> Home</a></li> <!-- Hamburger menu link -->
 					<?php if (checkMenu(2,$user->data()->id)){  //Links for permission level 2 (default admin) ?>
-						<li class="hidden-sm hidden-md hidden-lg"><a href="<?=$us_url_root?>users/admin.php"><i class="fa fa-fw fa-cogs"></i> Admin Dashboard</a></li> <!-- Hamburger menu link -->
+						<li class="hidden-sm hidden-md hidden-lg"><a href="<?=findPageLocation('admin.php')?>"><i class="fa fa-fw fa-cogs"></i> Admin Dashboard</a></li> <!-- Hamburger menu link -->
 					<?php } // is user an admin ?>
 					<li class="dropdown hidden-xs"><a class="dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-fw fa-cog"></i><b class="caret"></b></a> <!-- regular user menu -->
 						<ul class="dropdown-menu"> <!-- open tag for User dropdown menu -->
 							<li><a href="<?=$us_url_root?>"><i class="fa fa-fw fa-home"></i> Home</a></li> <!-- regular user menu link -->
-							<li><a href="<?=$us_url_root?>users/account.php"><i class="fa fa-fw fa-user"></i> Account</a></li> <!-- regular user menu link -->
+							<li><a href="<?=findPageLocation('account.php')?>"><i class="fa fa-fw fa-user"></i> Account</a></li> <!-- regular user menu link -->
 
 							<?php if (checkMenu(2,$user->data()->id)){  //Links for permission level 2 (default admin) ?>
 								<li class="divider"></li>
-								<li><a href="<?=$us_url_root?>users/admin.php"><i class="fa fa-fw fa-cogs"></i> Admin Dashboard</a></li> <!-- regular Admin menu link -->
+								<li><a href="<?=findPageLocation('admin.php')?>"><i class="fa fa-fw fa-cogs"></i> Admin Dashboard</a></li> <!-- regular Admin menu link -->
 							<?php } // is user an admin ?>
 							<li class="divider"></li>
-							<li><a href="<?=$us_url_root?>users/logout.php"><i class="fa fa-fw fa-sign-out"></i> Logout</a></li> <!-- regular Logout menu link -->
+							<li><a href="<?=findPageLocation('logout.php')?>"><i class="fa fa-fw fa-sign-out"></i> Logout</a></li> <!-- regular Logout menu link -->
 						</ul> <!-- close tag for User dropdown menu -->
 					</li>
 
-					<li class="hidden-sm hidden-md hidden-lg"><a href="<?=$us_url_root?>users/logout.php"><i class="fa fa-fw fa-sign-out"></i> Logout</a></li> <!-- regular Hamburger logout menu link -->
+					<li class="hidden-sm hidden-md hidden-lg"><a href="<?=findPageLocation('logout.php')?>"><i class="fa fa-fw fa-sign-out"></i> Logout</a></li> <!-- regular Hamburger logout menu link -->
 
 				<?php }else{ // no one is logged in so display default items ?>
-					<li><a href="<?=$us_url_root?>users/login.php" class=""><i class="fa fa-sign-in"></i> Login</a></li>
-					<li><a href="<?=$us_url_root?>users/join.php" class=""><i class="fa fa-plus-square"></i> Register</a></li>
+					<li><a href="<?=findPageLocation('login.php')?>" class=""><i class="fa fa-sign-in"></i> Login</a></li>
+					<li><a href="<?=findPageLocation('join.php')?>" class=""><i class="fa fa-plus-square"></i> Register</a></li>
 					<li class="dropdown"><a class="dropdown-toggle" href="#" data-toggle="dropdown"><i class="fa fa-life-ring"></i> Help <b class="caret"></b></a>
 					<ul class="dropdown-menu">
-					<li><a href="<?=$us_url_root?>users/forgot_password.php"><i class="fa fa-wrench"></i> Forgot Password</a></li>
+					<li><a href="<?=findPageLocation('forgot_password.php')?>"><i class="fa fa-wrench"></i> Forgot Password</a></li>
 					<?php if ($email_act){ //Only display following menu item if activation is enabled ?>
-					<li><a href="<?=$us_url_root?>users/verify_resend.php"><i class="fa fa-exclamation-triangle"></i> Resend Activation Email</a></li>
+					<li><a href="<?=findPageLocation('verify_resend.php')?>"><i class="fa fa-exclamation-triangle"></i> Resend Activation Email</a></li>
 					<?php }?>
 					</ul>
 					</li>

--- a/users/index.php
+++ b/users/index.php
@@ -20,10 +20,18 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ?>
 <?php
 require_once 'init.php';
-if(isset($user) && $user->isLoggedIn()){
-  Redirect::to($us_url_root.'users/account.php');
-}else{
-  Redirect::to($us_url_root.'users/login.php');
+if(isset($user) && $user->isLoggedIn()) {
+  if (!$dest = Config::get('homepage')) {
+    $dest = 'account.php';
+  }
+} else {
+  if (!$dest = Config::get('homepage_nologin')) {
+    $dest = 'login.php';
+  }
 }
+Redirect::to($dest);
+# If we get here then Redirect::to() failed - perhaps because of a circular redirect
+# caused by configuration of homepage=index.php. Inform user and die.
+bold('You have an error in your configuration setting your homepage. Either replace this index.php with your own or else set homepage to something besides "index.php" in your users/init.php configuration.');
 die();
 ?>

--- a/users/join.php
+++ b/users/join.php
@@ -198,7 +198,7 @@ if(Input::exists()){
 			} catch (Exception $e) {
 				die($e->getMessage());
 			}
-			Redirect::to($us_url_root.'users/joinThankYou.php');
+			Redirect::to('joinThankYou.php');
 		}
 
 	} //Validation and agreement checbox

--- a/users/logout.php
+++ b/users/logout.php
@@ -5,14 +5,14 @@ $user = new User();
 
 if(file_exists($abs_us_root.$us_url_root.'usersc/scripts/just_before_logout.php')){
 	require_once $abs_us_root.$us_url_root.'usersc/scripts/just_before_logout.php';
-}else{
-	//Feel free to change where the user goes after logout!
 }
 $user->logout();
 if(file_exists($abs_us_root.$us_url_root.'usersc/scripts/just_after_logout.php')){
 	require_once $abs_us_root.$us_url_root.'usersc/scripts/just_after_logout.php';
 }else{
 	//Feel free to change where the user goes after logout!
-	Redirect::to($us_url_root.'index.php');
+	if (!$dest = Config::get('homepage_nologin'))
+		$dest = 'index.php';
+	Redirect::to($dest);
 }
 ?>

--- a/users/profile.php
+++ b/users/profile.php
@@ -27,36 +27,33 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 if($user->isLoggedIn()) { $thisUserID = $user->data()->id;} else { $thisUserID = 0; }
 
-if(isset($_GET['id']))
-	{
+if(isset($_GET['id'])) {
 	$userID = Input::get('id');
-	
+} else {
+	$userID = $thisUserID;
+}
+if ($userID) {
 	$userQ = $db->query("SELECT * FROM profiles LEFT JOIN users ON user_id = users.id WHERE user_id = ?",array($userID));
 	$thatUser = $userQ->first();
 
-	if($thisUserID == $userID)
-		{
+	if($thisUserID == $userID) {
 		$editbio = ' <small><a href="edit_profile.php">Edit Bio</a></small>';
-		}
-	else
-		{
+	} else {
 		$editbio = '';
-		}
-	
+	}
+
 	$ususername = ucfirst($thatUser->username)."'s Profile";
 	$grav = get_gravatar(strtolower(trim($thatUser->email)));
 	$useravatar = '<img src="'.$grav.'" class="img-thumbnail" alt="'.$ususername.'">';
 	$usbio = html_entity_decode($thatUser->bio);
 	//Uncomment out the line below to see what's available to you.
 	//dump($thisUser);
-	}
-else
-	{
+} else {
 	$ususername = '404';
 	$usbio = 'User not found';
 	$useravatar = '';
 	$editbio = ' <small><a href="/">Go to the homepage</a></small>';
-	}
+}
 ?>
    <div id="page-wrapper">
 
@@ -70,18 +67,18 @@ else
 						<div class="col-xs-12 col-md-10">
 						<h1><?php echo $ususername;?></h1>
 							<h2><?php echo $usbio.$editbio;?></h2>
-	
+
 					</div>
 					</div>
 				</div>
-				
+
 										<a class="btn btn-success" href="view_all_users.php" role="button">All Users</a>
 
 
     </div> <!-- /container -->
 
 </div> <!-- /#page-wrapper -->
- 
+
 <!-- footers -->
 <?php require_once $abs_us_root.$us_url_root.'users/includes/page_footer.php'; // the final html footer copyright row + the external js calls ?>
 <!-- Place any per-page javascript here -->

--- a/users/verify.php
+++ b/users/verify.php
@@ -24,7 +24,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 <?php
 if($user->isLoggedIn()){
 	$user->logout();
-	Redirect::to($us_url_root.'users/verify.php');
+	Redirect::to('verify.php');
 }
 
 $verify_success=FALSE;

--- a/usersc/scripts/custom_login_script.php
+++ b/usersc/scripts/custom_login_script.php
@@ -2,5 +2,9 @@
 //Whatever you put here will happen after the username and password are verified and the user is "technically" logged in, but they have not yet been redirected to their starting page.  This gives you access to all the user's data through $user->data()
 
 //Where do you want to redirect the user after login
-Redirect::to($us_url_root.'users/account.php');
+if (!($dest = Config::get('homepage_login')) &&
+    !($dest = Config::get('homepage'))) {
+  $dest = 'account.php';
+}
+Redirect::to($dest);
 ?>

--- a/usersc/scripts/just_after_logout.php
+++ b/usersc/scripts/just_after_logout.php
@@ -1,5 +1,8 @@
 <?php
 //This is what happens after a user logs out. Where do you want to send them?  What do you want to do?
 
-Redirect::to($us_url_root.'index.php');
+if (!$dest = Config::get('homepage_nologin')) {
+  $dest = 'index.php';
+}
+Redirect::to($dest);
 ?>


### PR DESCRIPTION
Allows pages to be moved around without manipulating redirect paths and without manipulating navigation script. All locating of pages is done by means of a path which is user configurable (see findPageLocation() in us_helpers.php). The order of paths is as follows:
* root (in case user moves a page here for aesthetics)
* usersc (in case user alters a page and places it here)
* users (the usual)
* ./ (in case of unusual site setup)
* ../ (in case of unusual site setup)
* ../../ (in case of unusual site setup)
As soon as a given page is found as these paths are traversed, that is the one that will be used for navigation and redirection.

email_settings.php has been modified to remove the "bug detection" logic there since we would not *prefer* if it was just "verify" instead of "users/verify". (But the system should work even with that "bug" in place.)

This may be a better feature to implement in a 4.2 or perhaps even in 5. Your call.