### PR TITLE
Numeric usernames

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+users/init.php
+*~
+*.swp
+*.bak


### PR DESCRIPTION
I haven't tested this extensively, but it splits out User::findById() from User::findByEmailOrUsername() and also leaves User::find() untouched in case some 3rd party developer is using it.

With this commit numeric usernames work, at least as far as I have tested them (logging in and modifying the profile).