### PR TITLE
Make it possible to have spaces in the z_url_root

### DIFF
--- a/users/admin_pages.php
+++ b/users/admin_pages.php
@@ -30,7 +30,7 @@ $successes = [];
 //Get line from z_us_root.php that starts with $path
 $file = fopen($abs_us_root.$us_url_root."z_us_root.php","r");
 while(!feof($file)){
-	$currentLine=fgets($file);
+	$currentLine=str_replace(" ", "", fgets($file));
 	if (substr($currentLine,0,5)=='$path'){
 		//echo $currentLine;
 		//if here, then it found the line starting with $path so break to preserve $currentLine value


### PR DESCRIPTION
This has frustrated me so much, i sat literaly an hour trying to figure out why the script wouldn't detect my files. Thinking the $path variable was a real array i typed spaces between the commas. So by stripping whitespace the problem is solved. 