### PR TITLE
Added backslash to special characters in copyright messages

### DIFF
--- a/install/step4.php
+++ b/install/step4.php
@@ -128,7 +128,7 @@ if (!empty($_POST['submit'])) {
   $tz=$_POST['timezone'];
 
   $copyright_syn='$copyright_message = \'';
-  $copyright=$_POST['copyright'];
+  $copyright=addslashes($_POST['copyright']);
 
   $private_syn='$your_private_key = \'';
   $public_syn='$your_public_key = \'';


### PR DESCRIPTION
Fix for issue "Copyright message with apostrophe causes error" using addslashes(string)  function of PHP.